### PR TITLE
Rewrite event handler for removing reactions

### DIFF
--- a/events.js
+++ b/events.js
@@ -51,14 +51,14 @@ async function onInteraction(interaction) {
 }
 
 /**
- * Event handler for when a user removes a reaction from a message.
+ * Event handler for when a reaction is removed from a message.
  * Checks if the message has any reaction roles configured. If so, removes that
  * role from the user whose reaction was removed. Also re-adds the bot's
  * reaction if it is removed while a react-role is active.
  *
- * This is only fired when a user removes a reaction, either by clicking on an
- * emoji or through the message's "reactions" context menu. It is NOT fired when
- * a bot removes a reaction (Discord uses a seprate event for that).
+ * This is only fired when a single reaction is removed, either by clicking on
+ * an emoji or through the message's "reactions" context menu. It is NOT fired
+ * when a bot removes all reactions (Discord uses a seprate event for that).
  *
  * The user this handler receives is the user whose reaction was removed.
  * Discord does not tell us who actually removed that user's reaction. We can't
@@ -70,9 +70,11 @@ async function onReactionRemove(reaction, react_user) {
 	// Do we only remove the role if the user doesn't have any of the mapped
 	// reactions? Or do we remove when any of the emojis are un-reacted?
 
+	const emoji = reaction.emoji;
+
 	const role_id = await database.getRoleReact({
 		message_id: reaction.message.id,
-		emoji_id: emojiToKey(reaction.emoji),
+		emoji_id: emojiToKey(emoji),
 	});
 
 	// Ignore reactions on non-role-react posts
@@ -81,8 +83,8 @@ async function onReactionRemove(reaction, react_user) {
 	}
 
 	if (react_user === react_user.client.user) {
-		logger.info(`Replacing removed bot reaction ${stringify(reaction.emoji)}`);
-		return reaction.message.react(reaction.emoji);
+		logger.info(`Replacing removed bot reaction ${stringify(emoji)}`);
+		return reaction.message.react(emoji);
 	}
 
 	try {

--- a/events.js
+++ b/events.js
@@ -53,7 +53,8 @@ async function onInteraction(interaction) {
 /**
  * Event handler for when a user removes a reaction from a message.
  * Checks if the message has any reaction roles configured. If so, removes that
- * role from the user whose reaction was removed.
+ * role from the user whose reaction was removed. Also re-adds the bot's
+ * reaction if it is removed while a react-role is active.
  *
  * This is only fired when a user removes a reaction, either by clicking on an
  * emoji or through the message's "reactions" context menu. It is NOT fired when
@@ -68,7 +69,6 @@ async function onReactionRemove(reaction, react_user) {
 	// TODO How do we handle two emojis mapped to the same role?
 	// Do we only remove the role if the user doesn't have any of the mapped
 	// reactions? Or do we remove when any of the emojis are un-reacted?
-	// TODO re-react if bot's reaction is removed
 
 	const role_id = await database.getRoleReact({
 		message_id: reaction.message.id,
@@ -81,7 +81,8 @@ async function onReactionRemove(reaction, react_user) {
 	}
 
 	if (react_user === react_user.client.user) {
-		return;
+		logger.info(`Replacing removed bot reaction ${stringify(reaction.emoji)}`);
+		return reaction.message.react(reaction.emoji);
 	}
 
 	try {

--- a/events.js
+++ b/events.js
@@ -19,6 +19,7 @@ const database = require('./database');
 const logger = require('./logger');
 const {
 	detail,
+	emojiToKey,
 	stringify,
 } = require('./util');
 
@@ -50,6 +51,52 @@ async function onInteraction(interaction) {
 }
 
 /**
+ * Event handler for when a user removes a reaction from a message.
+ * Checks if the message has any reaction roles configured. If so, removes that
+ * role from the user whose reaction was removed.
+ *
+ * This is only fired when a user removes a reaction, either by clicking on an
+ * emoji or through the message's "reactions" context menu. It is NOT fired when
+ * a bot removes a reaction (Discord uses a seprate event for that).
+ *
+ * The user this handler receives is the user whose reaction was removed.
+ * Discord does not tell us who actually removed that user's reaction. We can't
+ * tell when an admin removes a reaction instead of the user themselves, so this
+ * handler will always just remove the role from the user.
+ */
+async function onReactionRemove(reaction, react_user) {
+	// TODO How do we handle two emojis mapped to the same role?
+	// Do we only remove the role if the user doesn't have any of the mapped
+	// reactions? Or do we remove when any of the emojis are un-reacted?
+	// TODO re-react if bot's reaction is removed
+
+	const role_id = await database.getRoleReact({
+		message_id: reaction.message.id,
+		emoji_id: emojiToKey(reaction.emoji),
+	});
+
+	// Ignore reactions on non-role-react posts
+	if (!role_id) {
+		return;
+	}
+
+	if (react_user === react_user.client.user) {
+		return;
+	}
+
+	try {
+		const member = await reaction.message.guild.members.fetch(react_user.id);
+		await member.roles.remove(role_id, 'Role bot removal');
+		logger.info(`Removed Role ${role_id} from ${stringify(react_user)}`);
+	} catch (err) {
+		logger.error(
+			`Failed to remove Role ${role_id} from ${stringify(react_user)}`,
+			err
+		);
+	}
+}
+
+/**
  * Event handler for when the bot is logged in.
  * Just logs the bot user we logged in as.
  */
@@ -60,6 +107,7 @@ function onReady(client) {
 module.exports = {
 	onGuildLeave,
 	onInteraction,
+	onReactionRemove,
 	onReady,
 };
 

--- a/main.js
+++ b/main.js
@@ -40,9 +40,11 @@ const client = new Discord.Client({
 		Discord.Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
 	],
 	partials: [
+		// https://discordjs.guide/popular-topics/reactions.html#listening-for-reactions-on-old-messages
 		Discord.Constants.PartialTypes.MESSAGE,
 		Discord.Constants.PartialTypes.CHANNEL,
-		Discord.Constants.PartialTypes.REACTION
+		Discord.Constants.PartialTypes.REACTION,
+		Discord.Constants.PartialTypes.USER,
 	],
 	presence: {
 		activities: [{

--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ client.on(Events.GUILD_CREATE, onGuildJoin);
 client.on(Events.GUILD_DELETE, events.onGuildLeave);
 client.on(Events.INTERACTION_CREATE, events.onInteraction);
 client.on(Events.MESSAGE_REACTION_ADD, onReactionAdd);
-client.on(Events.MESSAGE_REACTION_REMOVE, onReactionRemove);
+client.on(Events.MESSAGE_REACTION_REMOVE, events.onReactionRemove);
 
 
 client.login(CONFIG.token).catch(err => {
@@ -158,36 +158,6 @@ function onReactionAdd(reaction, user) {
 			)
 			.then(() => database.incrementAssignCounter())
 			.then(() => logger.info(`added role ${roleId} to ${user}`));
-		})
-		.catch(logError);
-}
-
-/**
- * Event handler for when a reaction is removed from a message.
- * Checks if the message has any reaction roles configured, removing a role from
- * the user who removed their reaction, if applicable. Ignored reacts removed by
- * this bot, of course.
- */
-function onReactionRemove(reaction, user) {
-	// TODO How do we handle two emojis mapped to the same role?
-	// Do we only remove the role if the user doesn't have any of the mapped
-	// reactions? Or do we remove when any of the emojis are un-reacted?
-
-	if (user === client.user) {
-		return;
-	}
-
-	let emoji = emojiIdFromEmoji(reaction.emoji);
-
-	cache.getReactRole(reaction.message.id, emoji)
-		.then(roleId => {
-			if (!roleId) {
-				return;
-			}
-
-			return reaction.message.guild.members.fetch(user.id)
-				.then(member => member.roles.remove(roleId, 'Role bot removal'))
-				.then(() => logger.info(`removed role ${roleId} from ${user}`))
 		})
 		.catch(logError);
 }

--- a/util.js
+++ b/util.js
@@ -60,7 +60,7 @@ function emojiToKey(emoji) {
 	if (!isEmoji(emoji)) {
 		throw Error(`Not an emoji key: ${emoji}`);
 	}
-	return emoji?.id ?? emoji;
+	return emoji?.id ?? emoji?.name ?? emoji;
 }
 
 /**


### PR DESCRIPTION
Also fixes an issue where an admin could remove the bot's reaction, causing the Discord message reactions and bot database to be out of sync.