### PR TITLE
Assert in database

### DIFF
--- a/database.js
+++ b/database.js
@@ -67,6 +67,15 @@ function _pickAndAssertFields(args, asserts) {
 }
 
 /**
+ * Simple assert to ensure value is a valid Discord ID.
+ */
+function _assertDiscordId(value) {
+	if (!isDiscordId(value)) {
+		throw Error(`Invalid Discord ID: ${value}`);
+	}
+}
+
+/**
  * Adds an emoji->role mapping for the given message. If the emoji is already
  * mapped to a role on this message, that mapping is replaced.
  *
@@ -109,6 +118,7 @@ function removeRoleReact(args) {
  * Removes all emoji->role mappings for the given message.
  */
 function removeAllRoleReacts(message_id) {
+	_assertDiscordId(message_id);
 	return knex(REACTS).where('message_id', message_id).del();
 }
 
@@ -133,6 +143,7 @@ function getRoleReact(args) {
  * null if the given message has no react roles set up.
  */
 function getRoleReactMap(message_id) {
+	_assertDiscordId(message_id);
 	return knex(REACTS)
 		.select(['emoji_id', 'role_id'])
 		.where('message_id', message_id)
@@ -150,6 +161,7 @@ function getRoleReactMap(message_id) {
  * Returns whether the given message has any role react mappings on it.
  */
 function isRoleReactMessage(message_id) {
+	_assertDiscordId(message_id);
 	return knex(REACTS)
 		.select('message_id')
 		.where('message_id', message_id)
@@ -161,6 +173,7 @@ function isRoleReactMessage(message_id) {
  * Deletes all the data stored for the given guild.
  */
 function clearGuildInfo(guild_id) {
+	_assertDiscordId(guild_id);
 	return Promise.all([REACTS, PERMS, MUTEX].map(table =>
 		knex(table).where('guild_id', guild_id).del()
 	));
@@ -221,6 +234,7 @@ function removeAllowedRole(args) {
  * Returns the list of roles that can configure this bot for the given guild.
  */
 function getAllowedRoles(guild_id) {
+	_assertDiscordId(guild_id);
 	return knex(PERMS)
 		.select('role_id')
 		.where({ guild_id: guild_id })
@@ -313,6 +327,11 @@ function getMutexRoles(args) {
  * instead of just an array.
  */
 function getMutexEmojis(roles) {
+	if (!Array.isArray(roles)) {
+		throw Error('roles must be an Array of Discord IDs');
+	}
+	roles.forEach(_assertDiscordId);
+
 	return knex(REACTS)
 		.select('emoji_id')
 		.whereIn('role_id', roles)

--- a/database.js
+++ b/database.js
@@ -22,10 +22,6 @@ const META = 'meta';
 const MUTEX = 'mutex';
 const PERMS = 'perms';
 const REACTS = 'reacts';
-const DISCORD_ID_LENGTH = {
-	MIN: 17,
-	MAX: 22,
-};
 
 /**
  * Adds an emoji->role mapping for the given message. If the emoji is already
@@ -263,11 +259,6 @@ function getMutexEmojis(roles) {
 }
 
 module.exports = {
-	DISCORD_ID_LENGTH,
-	META,
-	MUTEX,
-	PERMS,
-	REACTS,
 	addRoleReact,
 	removeRoleReact,
 	removeAllRoleReacts,

--- a/migrations/20200225015300_db.js
+++ b/migrations/20200225015300_db.js
@@ -17,6 +17,12 @@
 const DISCORD_ID_MAX = 19;
 const REACTS = 'reacts';
 
+/**
+ * Create a table mapping a reaction emoji to a role on a message in a guild.
+ *
+ * Using a composite primary key of message_id and emoji_id doubles as a thing
+ * that prevents multiple database entries for the same react.
+ */
 exports.up = function(knex) {
 	return knex.schema.createTable(REACTS, table => {
 		table.string('guild_id',   DISCORD_ID_MAX);

--- a/migrations/20200814190000_meta.js
+++ b/migrations/20200814190000_meta.js
@@ -16,6 +16,9 @@
  ******************************************************************************/
 const META = 'meta';
 
+/**
+ * Creates a table for counting how many total assignments there have been.
+ */
 exports.up = function(knex) {
 	return knex.schema.createTable(META, table => {
 		table.integer('assignments');

--- a/migrations/20200815043000_perms.js
+++ b/migrations/20200815043000_perms.js
@@ -17,6 +17,10 @@
 const DISCORD_ID_MAX = 19;
 const PERMS = 'perms';
 
+/**
+ * Creates a table that maps a role to a guild, so that role can be allowed to
+ * configure the bot in the guild.
+ */
 exports.up = function(knex) {
 	return knex.schema.createTable(PERMS, table => {
 		table.string('guild_id', DISCORD_ID_MAX);

--- a/migrations/20200818203000_mutex.js
+++ b/migrations/20200818203000_mutex.js
@@ -17,6 +17,9 @@
 const DISCORD_ID_MAX = 19;
 const MUTEX = 'mutex';
 
+/**
+ * Creates a table mapping two roles as mutually exclusive for a guild.
+ */
 exports.up = function(knex) {
 	return knex.schema.createTable(MUTEX, table => {
 		table.string('guild_id',  DISCORD_ID_MAX);

--- a/migrations/20211215035000_animated.js
+++ b/migrations/20211215035000_animated.js
@@ -17,8 +17,16 @@
 const REACTS = 'reacts';
 const EMOJI_ID = 'emoji_id';
 
+/**
+ * Animated emojis did not exist when this bot was first written. When Discord
+ * added them, the bot did not recognize their format, so it dumped the entire
+ * "toString" value to the database.
+ *
+ * That logic has since been fixed. This migration correspondingly fixes any
+ * broken animated emoji entries already in the database.
+ */
 exports.up = function(knex) {
-	console.error(
+	console.warn(
 		'Warning: this is a one-way migration. Animated emoji names cannot ' +
 		'be restored and will remain as IDs'
 	);

--- a/util.js
+++ b/util.js
@@ -27,6 +27,14 @@ const {
 const logger = require('./logger');
 
 /**
+ * Most IDs are between 17 and 19 characters, but I have seen some patterns
+ * matching to 20 for custom emoji IDs, so let's just future-proof this and
+ * match up to 22. If this bot is still being used by the time we need to update
+ * that, well, cool.
+ */
+const DISCORD_ID_PATTERN = RegExp('^\\d{17,22}$');
+
+/**
  * Joins the given array of strings using newlines.
  */
 function asLines(lines) {
@@ -62,7 +70,7 @@ function detail(thing) {
  * - Non-emoji strings are considered an error and will throw accordingly.
  */
 function emojiToKey(emoji) {
-	if (!isEmoji(emoji)) {
+	if (!_isEmoji(emoji)) {
 		throw Error(`Not an emoji key: ${emoji}`);
 	}
 	return emoji?.id ?? emoji?.name ?? emoji;
@@ -83,8 +91,22 @@ function ephemReply(interaction, content) {
 /**
  * Handles both custom Discord.js Emojis and standard unicode emojis.
  */
-function isEmoji(thing) {
-	return thing?.match?.(/^\p{Extended_Pictographic}$/u) || thing instanceof Emoji;
+function _isEmoji(thing) {
+	return isEmojiStr(thing) || thing instanceof Emoji;
+}
+
+/**
+ * Matches Discord IDs.
+ */
+function isDiscordId(str) {
+	return str?.match?.(DISCORD_ID_PATTERN);
+}
+
+/**
+ * Matches built-in unicode emoji literals.
+ */
+function isEmojiStr(str) {
+	return str?.match?.(/^\p{Extended_Pictographic}$/u);
 }
 
 /**
@@ -98,7 +120,7 @@ function stringify(thing) {
 	if (!thing) {
 		return '[undefined]';
 	}
-	else if (isEmoji(thing)) {
+	else if (_isEmoji(thing)) {
 		const emoji = thing;
 		return `Emoji ${emojiToKey(emoji)}`;
 	}
@@ -153,6 +175,8 @@ module.exports = {
 	detail,
 	emojiToKey,
 	ephemReply,
+	isDiscordId,
+	isEmojiStr,
 	stringify,
 	unindent,
 };


### PR DESCRIPTION
Add asserts to database as an extra layer of security on bad data (since SQLite3 is pretty permissive).
Also, add block comments explaining what each migration does, since they're not always obvious. 