### PR TITLE
Lock users when assigning or removing roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ todo.txt
 *.log
 *.swp
 *.sqlite3
-dev-config.json
+*-config.json
+invite

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -8,6 +8,11 @@ like https://github.com/nvm-sh/nvm.
 This guide assumes you're hosting on a Linux distro with `systemd`. The bot will
 work on other platforms, but you're on your own figuring that out.
 
+## Bot account setup
+
+Your bot account needs the privileged "Server Members Intent" enabled.
+It also needs [these permissions](../README.md#permissions).
+
 ## Running as a user (in dev-mode)
 
 Quick and easy. Also (mostly) platform-independent!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reactionrolebot",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.2",
       "license": "AGPL-3.0",
       "dependencies": {
+        "async-mutex": "^0.3.2",
         "discord-command-registry": "^1.2.2",
         "discord.js": "^13.7.0",
         "knex": "^0.20.13",
@@ -245,6 +246,14 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
       "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
+    "node_modules/async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3199,6 +3208,14 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
       "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
+    "async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "discord-command-registry": "^1.2.2",
-        "discord.js": "^13.3.1",
+        "discord.js": "^13.7.0",
         "knex": "^0.20.13",
         "lodash": "^4.17.20",
         "minimist": "^1.2.6",
@@ -665,57 +665,37 @@
       }
     },
     "node_modules/discord.js": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.6.0.tgz",
-      "integrity": "sha512-tXNR8zgsEPxPBvGk3AQjJ9ljIIC6/LOPjzKwpwz8Y1Q2X66Vi3ZqFgRHYwnHKC0jC0F+l4LzxlhmOJsBZDNg9g==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.7.0.tgz",
+      "integrity": "sha512-iV/An3FEB/CiBGdjWHRtgskM4UuWPq5vjhjKsrQhdVU16dbKrBxA+eIV2HWA07B3tXUGM6eco1wkr42gxxV1BA==",
       "dependencies": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/collection": "^0.4.0",
-        "@sapphire/async-queue": "^1.1.9",
-        "@types/node-fetch": "^2.5.12",
-        "@types/ws": "^8.2.2",
-        "discord-api-types": "^0.26.0",
+        "@discordjs/builders": "^0.13.0",
+        "@discordjs/collection": "^0.6.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@types/node-fetch": "^2.6.1",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.30.0",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
-        "ws": "^8.4.0"
+        "ws": "^8.6.0"
       },
       "engines": {
         "node": ">=16.6.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/discord.js/node_modules/@discordjs/builders": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
-      "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.2.0",
-        "discord-api-types": "^0.26.0",
-        "ts-mixer": "^6.0.0",
-        "tslib": "^2.3.1",
-        "zod": "^3.11.6"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/discord.js/node_modules/@discordjs/collection": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-      "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.6.0.tgz",
+      "integrity": "sha512-Ieaetb36l0nmAS5X9Upqk4W7euAO6FdXPxn3I8vBAKEcoIzEZI1mcVcPfCfagGJZSgBKpENnAnKkP4GAn+MV8w==",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/discord.js/node_modules/discord-api-types": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-      "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.30.0.tgz",
+      "integrity": "sha512-wYst0jrT8EJs2tVlwUTQ2xT0oWMjUrRMpFTkNY3NMleWyQNHgWaKhqFfxdLPdC2im9IuR5EsxcEgjhf/npeftw=="
     },
     "node_modules/enabled": {
       "version": "2.0.0",
@@ -3021,9 +3001,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3044,14 +3024,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "node_modules/zod": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.14.4.tgz",
-      "integrity": "sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   },
   "dependencies": {
@@ -3566,42 +3538,30 @@
       }
     },
     "discord.js": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.6.0.tgz",
-      "integrity": "sha512-tXNR8zgsEPxPBvGk3AQjJ9ljIIC6/LOPjzKwpwz8Y1Q2X66Vi3ZqFgRHYwnHKC0jC0F+l4LzxlhmOJsBZDNg9g==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.7.0.tgz",
+      "integrity": "sha512-iV/An3FEB/CiBGdjWHRtgskM4UuWPq5vjhjKsrQhdVU16dbKrBxA+eIV2HWA07B3tXUGM6eco1wkr42gxxV1BA==",
       "requires": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/collection": "^0.4.0",
-        "@sapphire/async-queue": "^1.1.9",
-        "@types/node-fetch": "^2.5.12",
-        "@types/ws": "^8.2.2",
-        "discord-api-types": "^0.26.0",
+        "@discordjs/builders": "^0.13.0",
+        "@discordjs/collection": "^0.6.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@types/node-fetch": "^2.6.1",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.30.0",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
-        "ws": "^8.4.0"
+        "ws": "^8.6.0"
       },
       "dependencies": {
-        "@discordjs/builders": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
-          "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
-          "requires": {
-            "@sindresorhus/is": "^4.2.0",
-            "discord-api-types": "^0.26.0",
-            "ts-mixer": "^6.0.0",
-            "tslib": "^2.3.1",
-            "zod": "^3.11.6"
-          }
-        },
         "@discordjs/collection": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-          "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw=="
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.6.0.tgz",
+          "integrity": "sha512-Ieaetb36l0nmAS5X9Upqk4W7euAO6FdXPxn3I8vBAKEcoIzEZI1mcVcPfCfagGJZSgBKpENnAnKkP4GAn+MV8w=="
         },
         "discord-api-types": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-          "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ=="
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.30.0.tgz",
+          "integrity": "sha512-wYst0jrT8EJs2tVlwUTQ2xT0oWMjUrRMpFTkNY3NMleWyQNHgWaKhqFfxdLPdC2im9IuR5EsxcEgjhf/npeftw=="
         }
       }
     },
@@ -5411,20 +5371,15 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
       "requires": {}
     },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "zod": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.14.4.tgz",
-      "integrity": "sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactionrolebot",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "I'm a basic, no BS Discord bot that can assign and unassign roles using message reactions. I am completely free and open source, and always will be.",
   "main": "src/main.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "I'm a basic, no BS Discord bot that can assign and unassign roles using message reactions. I am completely free and open source, and always will be.",
   "main": "src/main.js",
   "dependencies": {
+    "async-mutex": "^0.3.2",
     "discord-command-registry": "^1.2.2",
     "discord.js": "^13.7.0",
     "knex": "^0.20.13",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/main.js",
   "dependencies": {
     "discord-command-registry": "^1.2.2",
-    "discord.js": "^13.3.1",
+    "discord.js": "^13.7.0",
     "knex": "^0.20.13",
     "lodash": "^4.17.20",
     "minimist": "^1.2.6",

--- a/src/events.js
+++ b/src/events.js
@@ -12,6 +12,7 @@ const Perms = require('discord.js').Permissions.FLAGS;
 const commands = require('./commands');
 const config = require('./config');
 const database = require('./database');
+const UserMutex = require('./mutex');
 const logger = require('./logger');
 const {
 	detail,
@@ -19,6 +20,13 @@ const {
 	stringify,
 	unindent,
 } = require('./util');
+
+/**
+ * Allows us to "lock" a user to prevent multiple events from trying to update
+ * their roles at the same time. Any event that modifies a user should acquire
+ * a lock on that user first.
+ */
+const USER_MUTEX = new UserMutex();
 
 const REQUIRED_PERMISSIONS = Object.freeze({
 	[Perms.ADD_REACTIONS]:        'Add Reactions',
@@ -81,6 +89,15 @@ async function onGuildLeave(guild) {
 	} catch (err) {
 		logger.error(`Left ${stringify(guild)} but failed to delete data!`, err);
 	}
+}
+
+/**
+ * Event handler for when a guild member is updated.
+ * We use this to clear the user lock, since this event is fired once a
+ * user's roles are fully updated.
+ */
+async function onGuildMemberUpdate(old_member, new_member) {
+	USER_MUTEX.unlock(new_member);
 }
 
 /**
@@ -155,6 +172,7 @@ async function onReactionAdd(reaction, react_user) {
 	const member = await reaction.message.guild.members.fetch(react_user.id);
 
 	// Remove mutually exclusive roles from user
+	// FIXME this database call should optionally take an array
 	const mutex_roles = lodash.flatMap(
 		await Promise.all(role_ids.map(role_id => database.getMutexRoles({
 			guild_id: reaction.message.guild.id,
@@ -162,6 +180,7 @@ async function onReactionAdd(reaction, react_user) {
 		})))
 	);
 	try {
+		await USER_MUTEX.lock(member); // See USER_MUTEX comment
 		await member.roles.remove(mutex_roles, 'Role bot removal (mutex)');
 		await member.roles.add(role_ids, 'Role bot assignment');
 	} catch (err) {
@@ -226,6 +245,7 @@ async function onReactionRemove(reaction, react_user) {
 
 	try {
 		const member = await reaction.message.guild.members.fetch(react_user.id);
+		await USER_MUTEX.lock(member); // see USER_MUTEX comment
 		await member.roles.remove(role_ids, 'Role bot removal');
 		logger.info(`Removed Roles ${stringify(role_ids)} from ${stringify(react_user)}`);
 	} catch (err) {
@@ -303,6 +323,7 @@ async function precache(client) {
 module.exports = {
 	onGuildJoin,
 	onGuildLeave,
+	onGuildMemberUpdate,
 	onInteraction,
 	onMessageBulkDelete,
 	onMessageDelete,

--- a/src/events.js
+++ b/src/events.js
@@ -190,8 +190,8 @@ async function onReactionAdd(reaction, react_user) {
 			role_id: role_id,
 		})))
 	);
+	await USER_MUTEX.lock(member); // See USER_MUTEX comment
 	try {
-		await USER_MUTEX.lock(member); // See USER_MUTEX comment
 		await member.roles.remove(mutex_roles, 'Role bot removal (mutex)');
 		await member.roles.add(role_ids, 'Role bot assignment');
 	} catch (err) {
@@ -254,13 +254,13 @@ async function onReactionRemove(reaction, react_user) {
 		return reaction.message.react(emoji);
 	}
 
+	await USER_MUTEX.lock(react_user); // see USER_MUTEX comment
 	try {
 		const member = await reaction.message.guild.members.fetch(react_user.id);
-		await USER_MUTEX.lock(member); // see USER_MUTEX comment
 
 		// onGuildMemberUpdate won't fire if we don't actually change roles
 		if (!role_ids.some(role_id => member.roles.cache.has(role_id))) {
-			USER_MUTEX.unlock(member);
+			USER_MUTEX.unlock(react_user);
 			return;
 		}
 

--- a/src/events.js
+++ b/src/events.js
@@ -257,6 +257,13 @@ async function onReactionRemove(reaction, react_user) {
 	try {
 		const member = await reaction.message.guild.members.fetch(react_user.id);
 		await USER_MUTEX.lock(member); // see USER_MUTEX comment
+
+		// onGuildMemberUpdate won't fire if we don't actually change roles
+		if (!role_ids.some(role_id => member.roles.cache.has(role_id))) {
+			USER_MUTEX.unlock(member);
+			return;
+		}
+
 		await member.roles.remove(role_ids, 'Role bot removal');
 		logger.info(`Removed Roles ${stringify(role_ids)} from ${stringify(react_user)}`);
 	} catch (err) {

--- a/src/main.js
+++ b/src/main.js
@@ -20,11 +20,13 @@ const client = new Discord.Client({
 	intents: [
 		Discord.Intents.FLAGS.GUILDS,
 		Discord.Intents.FLAGS.GUILD_EMOJIS_AND_STICKERS,
+		Discord.Intents.FLAGS.GUILD_MEMBERS,
 		Discord.Intents.FLAGS.GUILD_MESSAGES,
 		Discord.Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
 	],
 	partials: [
 		// https://discordjs.guide/popular-topics/reactions.html#listening-for-reactions-on-old-messages
+		Discord.Constants.PartialTypes.GUILD_MEMBER,
 		Discord.Constants.PartialTypes.MESSAGE,
 		Discord.Constants.PartialTypes.CHANNEL,
 		Discord.Constants.PartialTypes.REACTION,
@@ -42,6 +44,7 @@ const Events = Discord.Constants.Events;
 client.on(Events.CLIENT_READY, events.onReady);
 client.on(Events.GUILD_CREATE, events.onGuildJoin);
 client.on(Events.GUILD_DELETE, events.onGuildLeave);
+client.on(Events.GUILD_MEMBER_UPDATE, events.onGuildMemberUpdate);
 client.on(Events.INTERACTION_CREATE, events.onInteraction);
 client.on(Events.MESSAGE_BULK_DELETE, events.onMessageBulkDelete);
 client.on(Events.MESSAGE_DELETE, events.onMessageDelete);

--- a/src/mutex.js
+++ b/src/mutex.js
@@ -1,0 +1,62 @@
+const { Mutex } = require('async-mutex');
+
+const logger = require('./logger');
+const { stringify } = require('./util');
+
+/**
+ * A Mutex that knows how many things are waiting to acquire it.
+ *
+ * NOTE: Mutex::release is not actually deprecated. See:
+ * https://github.com/DirtyHairy/async-mutex/issues/50#issuecomment-1007785141
+ */
+class ReferenceCountMutex extends Mutex {
+	ref_count = 0;
+
+	async acquire() {
+		this.ref_count++;
+		return await super.acquire();
+	}
+
+	release() {
+		this.ref_count--;
+		super.release();
+	}
+}
+
+/**
+ * A map of mutexes that can lock Discord GuildMembers, preventing race
+ * conditions when modifying users across multiple events.
+ *
+ * Uses reference counting to clean up mutexes.
+ */
+class UserMutex {
+	#mutexes = new Map();
+
+	// TODO this needs a timeout
+	async lock(user) {
+		const key = user.id;
+		if (!this.#mutexes.has(key)) {
+			this.#mutexes.set(key, new ReferenceCountMutex());
+		}
+		const mutex = this.#mutexes.get(key);
+		logger.debug(`Locking ${stringify(user)} (refs: ${mutex.ref_count})`);
+		return await mutex.acquire();
+	}
+
+	unlock(user) {
+		const key = user.id;
+		if (!this.#mutexes.has(key)) {
+			return;
+		}
+		const mutex = this.#mutexes.get(key);
+		logger.debug(`Unlocking ${stringify(user)} (refs: ${mutex.ref_count})`);
+		mutex.release();
+
+		// Clean up locks once nothing else is using them
+		if (mutex.ref_count === 0) {
+			this.#mutexes.delete(key);
+		}
+	}
+}
+
+module.exports = UserMutex;

--- a/src/util.js
+++ b/src/util.js
@@ -9,6 +9,7 @@
 const {
 	Emoji,
 	Guild,
+	GuildMember,
 	Interaction,
 	Message,
 	MessageReaction,
@@ -165,6 +166,10 @@ function stringify(thing) {
 	else if (thing instanceof User) {
 		const user = thing;
 		return `User ${user.id}`;
+	}
+	else if (thing instanceof GuildMember) {
+		const member = thing;
+		return `User ${member.id}`; // Same as member.user.id
 	}
 	else if (Array.isArray(thing)) {
 		return thing.map(t => stringify(t)).join(', ');

--- a/src/util.js
+++ b/src/util.js
@@ -105,7 +105,7 @@ function ephemReply(interaction, content) {
  * Handles both custom Discord.js Emojis and standard unicode emojis.
  */
 function _isEmoji(thing) {
-	return isEmojiStr(thing) || thing instanceof Emoji;
+	return !isDiscordId(thing) && (isEmojiStr(thing) || thing instanceof Emoji);
 }
 
 /**


### PR DESCRIPTION
This change "locks" users when assigning or removing roles. This fixes a race condition where mutually exclusive roles are not being assigned correctly. (See #65 )

Note: the code is using a "mutex lock", as in, a mutual-exclusion lock as seen in concurrent programming paradigms. Confusingly, this mechanism shares a name with the bot's mutually exclusive (or "mutex") role feature, and was also necessary to fix a bug in the mutually exclusive role feature. However, these two concepts are totally distinct. One is a concept in asynchronous programming. The other just stops you from having two specific Discord roles.

Names are hard :face_exhaling: 